### PR TITLE
Fix: CSS Windows import statement

### DIFF
--- a/configurable/index.js
+++ b/configurable/index.js
@@ -39,7 +39,7 @@ const sveltePlugin = options => {
 
                     //if svelte emits css seperately, then store it in a map and import it from the js
                     if (!compileOptions.css && css.code) {
-                        let cssPath = args.path.replace(".svelte", ".esbuild-svelte-fake-css")
+                        let cssPath = args.path.replace(".svelte", ".esbuild-svelte-fake-css").replace(/\\/g, "/");
                         cssCode.set(cssPath, css.code + `/*# sourceMappingURL=${css.map.toUrl()}*/`);
                         contents = `import "${cssPath}";\n` + contents;
                     }


### PR DESCRIPTION
Hello and thank you for this plugin. I had an issue when trying to bundle the svelte app with `css` option set to false on Windows 10 system with Node v14. 

Screenshot error:

![image](https://user-images.githubusercontent.com/35178536/99891300-3e61a000-2c60-11eb-9340-b75eb35da5ac.png)

After my PR the issue is fixed. It will replace forward slashes (`\`) with backward slashes (`/`) for the import to work.

![image](https://user-images.githubusercontent.com/35178536/99891303-4de0e900-2c60-11eb-9f8a-3c48e305a59c.png)
