### PR TITLE
Add "include" option, rename "compileOptions"

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5,6 +5,7 @@ interface esbuildSvelteOptions {
     /**
      * Svelte compiler options
      */
+    compilerOptions?: CompileOptions;
     compileOptions?: CompileOptions;
     /**
      * The preprocessor(s) to run the Svelte code through before compiling
@@ -20,6 +21,7 @@ interface esbuildSvelteOptions {
      * Defaults to `false` for now until support is added
      */
     fromEntryFile?: boolean;
+    include?: RegExp;
 }
 export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin;
 export {};


### PR DESCRIPTION
Hey @EMH333, just opening this as a draft for now to get your feedback. Plz disregard the dist/ and gitignore changes; if you're interested in this PR I'll fix it up and remove them.

* Adds an `include` option, similar to the svelte rollup plugin's `include` option. This is necessary to support mixing/matching webcomponents. In general, we include the plugin twice. Once with `compilerOptions.customElement = true` and `include: /\.wc\.svelte$/`, and a second time without `customElement` and with `exclude: /\.wc\.svelte$/`. I couldn't figure out how to make `exclude` work so I only did `include`, and it works well enough for our production build 🙂 
* Renamed `compileOptions` to `compilerOptions` -- small thing, but this lets you import your `svelte.config.js` and just use that object instead of having to copy in both the compilerOptions and preprocess settings

Let me know what you think, thanks!