### PR TITLE
Added filterWarnings option, fixes #85

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -32,7 +32,7 @@ interface esbuildSvelteOptions {
      * A function to filter out warnings
      * Defaults to a constant function that returns `true`
      */
-    filterWarnings?: (warning: Warning, index: number, warnings: Warning[]) => boolean;
+    filterWarnings?: (warning: Warning) => boolean;
 }
 export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin;
 export {};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -28,6 +28,11 @@ interface esbuildSvelteOptions {
      * Defaults to `/\.svelte$/`
      */
     include?: RegExp;
+    /**
+     * A function to filter out warnings
+     * Defaults to a constant function that returns `true`
+     */
+    filterWarnings?: Function;
 }
 export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin;
 export {};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import type { CompileOptions } from "svelte/types/compiler/interfaces";
+import type { CompileOptions, Warning } from "svelte/types/compiler/interfaces";
 import type { PreprocessorGroup } from "svelte/types/compiler/preprocess/types";
 import type { Plugin } from "esbuild";
 interface esbuildSvelteOptions {
@@ -32,7 +32,7 @@ interface esbuildSvelteOptions {
      * A function to filter out warnings
      * Defaults to a constant function that returns `true`
      */
-    filterWarnings?: Function;
+    filterWarnings?: (warning: Warning, index: number, warnings: Warning[]) => boolean;
 }
 export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin;
 export {};

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,12 @@ interface esbuildSvelteOptions {
      * Defaults to `/\.svelte$/`
      */
     include?: RegExp;
+
+    /**
+     * A function to filter out warnings
+     * Defaults to a constant function that returns `true`
+     */
+    filterWarnings?: Function;
 }
 
 interface CacheData {
@@ -97,6 +103,11 @@ export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin {
             // disable entry file generation by default
             if (options.fromEntryFile == undefined) {
                 options.fromEntryFile = false;
+            }
+
+            // by default all warnings are enabled
+            if (options.filterWarnings == undefined) {
+                options.filterWarnings = () => true;
             }
 
             //Store generated css code for use in fake import
@@ -237,7 +248,7 @@ export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin {
 
                     const result: OnLoadResult = {
                         contents,
-                        warnings: warnings.map(convertMessage),
+                        warnings: warnings.filter(options?.filterWarnings).map(convertMessage),
                     };
 
                     // if we are told to cache, then cache

--- a/index.ts
+++ b/index.ts
@@ -44,7 +44,7 @@ interface esbuildSvelteOptions {
      * A function to filter out warnings
      * Defaults to a constant function that returns `true`
      */
-    filterWarnings?: Function;
+    filterWarnings?: (warning: Warning, index: number, warnings: Warning[]) => boolean;
 }
 
 interface CacheData {
@@ -246,9 +246,13 @@ export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin {
                         contents = contents + `\nimport "${cssPath}";`;
                     }
 
+                    if (options?.filterWarnings) {
+                        warnings = warnings.filter(options.filterWarnings);
+                    }
+
                     const result: OnLoadResult = {
                         contents,
-                        warnings: warnings.filter(options?.filterWarnings).map(convertMessage),
+                        warnings: warnings.map(convertMessage),
                     };
 
                     // if we are told to cache, then cache

--- a/index.ts
+++ b/index.ts
@@ -44,7 +44,7 @@ interface esbuildSvelteOptions {
      * A function to filter out warnings
      * Defaults to a constant function that returns `true`
      */
-    filterWarnings?: (warning: Warning, index: number, warnings: Warning[]) => boolean;
+    filterWarnings?: (warning: Warning) => boolean;
 }
 
 interface CacheData {

--- a/test/fixtures/warnings/entry.js
+++ b/test/fixtures/warnings/entry.js
@@ -1,0 +1,5 @@
+import Test from "./missing-declaration.svelte";
+
+new Test({
+    target: document.body,
+});

--- a/test/fixtures/warnings/missing-declaration.svelte
+++ b/test/fixtures/warnings/missing-declaration.svelte
@@ -1,0 +1,7 @@
+<div>
+  {#if MY_GLOBAL}
+  <p>MY_GLOBAL is truthy</p>
+  {:else}
+  <p>MY_GLOBAL is falsy</p>
+  {/if}
+</div>

--- a/test/fixtures/warnings/missing-declaration.svelte
+++ b/test/fixtures/warnings/missing-declaration.svelte
@@ -1,7 +1,11 @@
 <div>
+  <!-- This will generate a warning about unknown MY_GLOBAL -->
   {#if MY_GLOBAL}
   <p>MY_GLOBAL is truthy</p>
   {:else}
   <p>MY_GLOBAL is falsy</p>
   {/if}
+
+  <!-- This will generate a warning about missing alt -->
+  <img src="foo.jpg" />
 </div>

--- a/test/warnings.mjs
+++ b/test/warnings.mjs
@@ -1,0 +1,51 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { build as _build } from "esbuild";
+import { typescript } from "svelte-preprocess-esbuild";
+import sveltePlugin from "../dist/index.mjs";
+
+test("Can filter out warnings", async () => {
+    const resultsWithoutFilter = await _build({
+        entryPoints: ["./test/fixtures/warnings/entry.js"],
+        outdir: "../example/dist",
+        bundle: true,
+        write: false, //Don't write anywhere
+        sourcemap: true,
+        plugins: [
+            sveltePlugin({
+                preprocess: typescript(),
+                compilerOptions: { dev: true },
+            }),
+        ],
+        logLevel: "silent",
+    });
+
+    const resultsWithFilter = await _build({
+        entryPoints: ["./test/fixtures/warnings/entry.js"],
+        outdir: "../example/dist",
+        bundle: true,
+        write: false, //Don't write anywhere
+        sourcemap: true,
+        plugins: [
+            sveltePlugin({
+                preprocess: typescript(),
+                compilerOptions: { dev: true },
+                filterWarnings: (warning) => {
+                    if (warning.code !== "missing-declaration") {
+                        return true;
+                    }
+
+                    return !warning.message.startsWith("'MY_GLOBAL' is not defined");
+                },
+            }),
+        ],
+        logLevel: "silent",
+    });
+
+    assert.equal(resultsWithoutFilter.warnings.length, 1, "Should have one warning");
+    assert.equal(resultsWithoutFilter.errors.length, 0, "Should not have errors");
+    assert.equal(resultsWithFilter.warnings.length, 0, "Should not have a warning");
+    assert.equal(resultsWithFilter.errors.length, 0, "Should not have errors");
+});
+
+test.run();

--- a/test/warnings.mjs
+++ b/test/warnings.mjs
@@ -31,20 +31,29 @@ test("Can filter out warnings", async () => {
                 preprocess: typescript(),
                 compilerOptions: { dev: true },
                 filterWarnings: (warning) => {
-                    if (warning.code !== "missing-declaration") {
-                        return true;
+                    // Ignore warning about the missing MY_GLOBAL.
+                    if (
+                        warning.code === "missing-declaration" &&
+                        warning.message.startsWith("'MY_GLOBAL' is not defined")
+                    ) {
+                        return false;
                     }
 
-                    return !warning.message.startsWith("'MY_GLOBAL' is not defined");
+                    return true;
                 },
             }),
         ],
         logLevel: "silent",
     });
 
-    assert.equal(resultsWithoutFilter.warnings.length, 1, "Should have one warning");
+    assert.equal(resultsWithoutFilter.warnings.length, 2, "Should have two warnings");
     assert.equal(resultsWithoutFilter.errors.length, 0, "Should not have errors");
-    assert.equal(resultsWithFilter.warnings.length, 0, "Should not have a warning");
+    assert.equal(resultsWithFilter.warnings.length, 1, "Should have one warning");
+    assert.equal(
+        resultsWithFilter.warnings[0].text,
+        "A11y: <img> element should have an alt attribute",
+        "The not filtered warning is still there"
+    );
     assert.equal(resultsWithFilter.errors.length, 0, "Should not have errors");
 });
 


### PR DESCRIPTION
For context https://github.com/sveltejs/svelte/issues/7240

I have no idea about TypeScript and why it thinks `options` could be undefined given this:

https://github.com/EMH333/esbuild-svelte/blob/589870f2144eb6c525aad8b96ac80150cfc8b7f4/index.ts#L88-L90

Anyway, if I disable the TypeScript checks then `npm run build && npm test` succeeds. Could you please clean this up (`warnings.filter(options?.filterWarnings)` doesn't look correct)? I need a way to filter out false positive warnings. I don't understand why Rollup uses a callback pattern. This PR solves my problem but might have some shortcoming? idk