### PR TITLE
Added new skipCss option

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,12 @@ interface esbuildSvelteOptions {
     cache?: boolean | "overzealous";
 
     /**
+     * Skip including and bundling an external CSS file.
+     * By default css is processed according to compilerOptions.css
+     */
+    skipCss?: boolean;
+
+    /**
      * Should esbuild-svelte create a binding to an html element for components given in the entryPoints list
      * Defaults to `false` for now until support is added
      */
@@ -92,6 +98,11 @@ export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin {
             // also checks if it has already been defined and ignores this if it has
             if (options.cache == undefined && shouldCache(build)) {
                 options.cache = true;
+            }
+
+            // process css by default
+            if (options.skipCss == undefined) {
+                options.skipCss = false;
             }
 
             // disable entry file generation by default
@@ -223,8 +234,9 @@ export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin {
 
                     let contents = js.code + `\n//# sourceMappingURL=` + toUrl(js.map.toString());
 
-                    //if svelte emits css seperately, then store it in a map and import it from the js
-                    if (!compilerOptions.css && css.code) {
+                    // if svelte emits css seperately, then store it in a map and import it from the js
+                    // unless we want to skip css entirely
+                    if (!compilerOptions.css && css.code && !options?.skipCss) {
                         let cssPath = args.path
                             .replace(".svelte", ".esbuild-svelte-fake-css") //TODO append instead of replace to support different svelte filters
                             .replace(/\\/g, "/");


### PR DESCRIPTION
This is WIP (docs, tests) but I wanted to get your approval.

I've added Svelte support to Harp, my favorite static website generator (http://harpjs.com/, https://github.com/sintaxi/terraform/pull/154)

There's one issue though: the generated static HTML (completely without JavaScript) is embedding the generated CSS. This works as expected. However, now if a component needs to be hydrated then the client side JS includes the CSS _again_ (with `css: true`), which is entirely unnecessary. Using `css: false` does not work, because compilation happens entirely in-memory (using esbuild `stdin`). So even if we ignore the fact that I don't need CSS _at all_ for the client bundle, it also wouldn't work because `stdin` cannot import the external CSS file. There's no filesystem.

So I need an option to compile a Svelte component without any CSS whatsoever. 