### PR TITLE
Set esbuild main fields to properly bundle Svelte components from npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ import sveltePlugin from "esbuild-svelte";
 esbuild
   .build({
     entryPoints: ["app.js"],
+    mainFields: ["svelte", "browser", "module", "main"],
     bundle: true,
     outfile: "out.js",
     plugins: [sveltePlugin()],
@@ -43,6 +44,7 @@ import sveltePreprocess from "svelte-preprocess";
 esbuild
   .build({
     entryPoints: ["index.js"],
+    mainFields: ["svelte", "browser", "module", "main"],
     bundle: true,
     outdir: "./dist",
     plugins: [


### PR DESCRIPTION
Was about to open a bug report, but this seems to fix my problem:

I'm currently running into https://github.com/sveltejs/svelte/issues/6600 (also https://github.com/sveltejs/svelte/issues/3165 in the past)

Basically I want to use a Svelte component from npm, but esbuild will look at `main`/ `browser` and include the compiled version. But it needs to load the raw Svelte code. So you end up with two version of Svelte in the same project, causing the crash.

See https://github.com/zerodevx/svelte-toast/blob/281f95da2b6252d6756c053e302c6bd2a645ddb7/package.json#L6

And of course esbuild already has a solution, as always: https://esbuild.github.io/api/#main-fields

**FWIW people might be bundling multiple Svelte versions all the time and don't realize, because it will only run into conflicts when both use transitions I think**