### PR TITLE
Correctly provide file locations for errors and warnings when using preprocessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased (Breaking)
 
-- Update development esbuild version to `0.19.0`
-
-  This means that this plugin now supports additional inhancements when using the `context` esbuild `v0.17.0` API as detailed below.
-
 - **Minorly Breaking** Caching is automatically enabled after two sucessful builds when using the `context` esbuild API
 
   Previously caching was automatically enabled when using the watch or incremental esbuild options, but those were removed in esbuild `v0.17.0`. This change brings back the automatic cache enabling when using the `context` API which supports the same features as the previous watch and incremental options. esbuild does not provide a way for plugins to determine if the `context` API is being used, so this feature is enabled after two successful builds. This should be a reasonable compromise between not enabling the cache at all and enabling it for every build (which wastes time and space if caching isn't needed).
@@ -15,6 +11,10 @@
 - **Minorly Breaking** Add dependency to `@jridgewell/trace-mapping` so error messages are more accurate when using preprocessors ([#83](https://github.com/EMH333/esbuild-svelte/issues/83))
 
   If you are using Svelte 4, this doesn't add additional dependencies because that package is already required by Svelte 4.
+
+- Update development esbuild version to `0.19.0`
+
+  This means that this plugin now supports additional inhancements when using the `context` esbuild `v0.17.0` API as detailed below.
 
 ## 0.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
   If you are using the `context` API and want to disable the cache, you can set the `cache` option to `false` in the plugin options but this isn't recommended (if you do need to disable the cache for some reason, please open an issue to see if your usecase can be fixed).
 
+- **Minorly Breaking** Add dependency to `@jridgewell/trace-mapping` so error messages are more accurate when using preprocessors ([#83](https://github.com/EMH333/esbuild-svelte/issues/83))
+
+  If you are using Svelte 4, this doesn't add additional dependencies because that package is already required by Svelte 4.
+
 ## 0.7.4
 
 - Lock Svelte peerDependency to `>=3.43.0 <5` to protect against breaking changes in future Svelte releases

--- a/index.ts
+++ b/index.ts
@@ -323,7 +323,14 @@ export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin {
                     return result;
                 } catch (e: any) {
                     let result: OnLoadResult = {};
-                    result.errors = [await convertMessage(e, args.path, originalSource, compilerOptions.sourcemap)];
+                    result.errors = [
+                        await convertMessage(
+                            e,
+                            args.path,
+                            originalSource,
+                            compilerOptions.sourcemap,
+                        ),
+                    ];
                     // only provide if context API is supported or we are caching
                     if (build.esbuild?.context !== undefined || shouldCache(build)) {
                         result.watchFiles = previousWatchFiles;

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import { readFile, statSync } from "fs";
 import { originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
 
 import type { CompileOptions, Warning } from "svelte/types/compiler/interfaces";
-import type { PreprocessorGroup } from "svelte/types/compiler/preprocess"
+import type { PreprocessorGroup } from "svelte/types/compiler/preprocess";
 import type { OnLoadResult, Plugin, PluginBuild, Location, PartialMessage } from "esbuild";
 
 interface esbuildSvelteOptions {
@@ -57,7 +57,7 @@ async function convertMessage(
     { message, start, end }: Warning,
     filename: string,
     source: string,
-    sourcemap: any
+    sourcemap: any,
 ): Promise<PartialMessage> {
     let location: Partial<Location> | undefined;
     if (start && end) {
@@ -300,9 +300,9 @@ export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin {
                                         e,
                                         args.path,
                                         source,
-                                        compilerOptions.sourcemap
-                                    )
-                            )
+                                        compilerOptions.sourcemap,
+                                    ),
+                            ),
                         ),
                     };
 

--- a/index.ts
+++ b/index.ts
@@ -324,7 +324,7 @@ export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin {
                     return result;
                 } catch (e: any) {
                     let result: OnLoadResult = {};
-                    result.errors = [await convertMessage(e, args.path, originalSource, null)];
+                    result.errors = [await convertMessage(e, args.path, originalSource, compilerOptions.sourcemap)];
                     // only provide if context API is supported or we are caching
                     if (build.esbuild?.context !== undefined || shouldCache(build)) {
                         result.watchFiles = previousWatchFiles;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "esbuild-svelte",
       "version": "0.7.4",
       "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.7.4"
+      },
       "devDependencies": {
         "@types/node": "^16.18.37",
         "esbuild": "^0.19.2",
@@ -874,6 +877,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -1511,6 +1522,11 @@
         "immutable": "^4.0.0",
         "source-map-js": ">=0.6.2 <2.0.0"
       }
+    },
+    "source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
     },
     "source-map-js": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
-        "source-map": "^0.7.4"
+        "@jridgewell/trace-mapping": "^0.3.18"
       },
       "devDependencies": {
         "@types/node": "^16.18.37",
@@ -414,7 +414,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -438,7 +437,6 @@
       "version": "0.3.18",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
       "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -447,8 +445,7 @@
     "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.1",
@@ -877,14 +874,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -1172,8 +1161,7 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -1191,7 +1179,6 @@
       "version": "0.3.18",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
       "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -1200,8 +1187,7 @@
         "@jridgewell/sourcemap-codec": {
           "version": "1.4.14",
           "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-          "dev": true
+          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         }
       }
     },
@@ -1522,11 +1508,6 @@
         "immutable": "^4.0.0",
         "source-map-js": ">=0.6.2 <2.0.0"
       }
-    },
-    "source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
     },
     "source-map-js": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   },
   "engines": {
     "node": ">=14"
+  },
+  "dependencies": {
+    "source-map": "^0.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "node": ">=14"
   },
   "dependencies": {
-    "source-map": "^0.7.4"
+    "@jridgewell/trace-mapping": "^0.3.18"
   }
 }

--- a/test/errors.mjs
+++ b/test/errors.mjs
@@ -1,0 +1,47 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { build as _build } from "esbuild";
+import { typescript } from "svelte-preprocess-esbuild";
+import sveltePlugin from "../dist/index.mjs";
+
+test("Errors (with preprocessors) are in the right spot", async () => {
+    try {
+        await _build({
+            entryPoints: ["./test/fixtures/errors/entry.js"],
+            outdir: "../example/dist",
+            bundle: true,
+            write: false, //Don't write anywhere
+            sourcemap: true,
+            plugins: [
+                sveltePlugin({
+                    preprocess: [typescript()],
+                    compilerOptions: { dev: true },
+                }),
+            ],
+            logLevel: "silent",
+        });
+    } catch (e) {
+        assert.equal(e.errors.length, 1, "Should have one error");
+        assert.equal(e.warnings.length, 0, "Should not have warnings");
+
+        const error = e.errors[0];
+
+        assert.equal(
+            error.location.file,
+            "test/fixtures/errors/error.svelte",
+            "Should have the right file"
+        );
+        assert.equal(error.location.line, 12, "Should have the right line");
+        assert.equal(error.location.column, 31, "Should have the right column");
+        assert.equal(
+            error.text,
+            "Expected value for the attribute",
+            "Should have the right error message"
+        );
+        return;
+    }
+
+    assert.unreachable("Should have thrown an error");
+});
+
+test.run();

--- a/test/errors.mjs
+++ b/test/errors.mjs
@@ -29,14 +29,14 @@ test("Errors (with preprocessors) are in the right spot", async () => {
         assert.equal(
             error.location.file,
             "test/fixtures/errors/error.svelte",
-            "Should have the right file"
+            "Should have the right file",
         );
         assert.equal(error.location.line, 12, "Should have the right line");
         assert.equal(error.location.column, 31, "Should have the right column");
         assert.equal(
             error.text,
             "Expected value for the attribute",
-            "Should have the right error message"
+            "Should have the right error message",
         );
         return;
     }

--- a/test/fixtures/errors/entry.js
+++ b/test/fixtures/errors/entry.js
@@ -1,0 +1,5 @@
+import Test from "./error.svelte";
+
+new Test({
+    target: document.body,
+});

--- a/test/fixtures/errors/error.svelte
+++ b/test/fixtures/errors/error.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  interface Test {
+    yellThisThing: String;
+  }
+
+  // some sort of javascript error
+  function event() {
+    console.log({ yellThisThing: "something" } as Test);
+  }
+</script>
+
+<button on:click={event} class=>Yell "something"</button>

--- a/test/fixtures/errors/svelte.config.js
+++ b/test/fixtures/errors/svelte.config.js
@@ -1,0 +1,6 @@
+const { typescript } = require("svelte-preprocess-esbuild");
+const { sass } = require("svelte-preprocess-sass");
+
+module.exports = {
+    preprocess: [{ style: sass() }, typescript()],
+};

--- a/test/fixtures/preprocessing-sourcemaps/pp-sourcemaps.svelte
+++ b/test/fixtures/preprocessing-sourcemaps/pp-sourcemaps.svelte
@@ -1,33 +1,35 @@
 <script lang="typescript">
-    interface Test {
-        yellThisThing: String;
-    }
+  interface Test {
+    yellThisThing: String;
+  }
 
-    function event() {
-        tryThisThing({ yellThisThing: "something!" });
-        change();
-    }
+  function event() {
+    tryThisThing({ yellThisThing: "something!" });
+    change();
+  }
 
-    function tryThisThing(input: Test) {
-        console.log(input.yellThisThing.toUpperCase());
-    }
+  function tryThisThing(input: Test) {
+    console.log(input.yellThisThing.toUpperCase());
+  }
 
-    let inputBinding: HTMLInputElement;
+  let inputBinding: HTMLInputElement;
 
-    function change() {
-        inputBinding.value = "testing" + Math.round(Math.random() * 100);
-    }
+  function change() {
+    inputBinding.value = "testing" + Math.round(Math.random() * 100);
+  }
 </script>
-
-<style lang="scss">
-    @use "sourcemapImport.scss";
-    @use "sass:color";
-    .sourcemap {
-        $primary-color: #6b717f;
-        color: $primary-color;
-        border: 1px solid color.scale($primary-color, $lightness: 20%);
-    }
-</style>
 
 <button on:click={event} class="sourcemap">Yell "something"</button>
 <input type="text" name="testingInput" bind:this={inputBinding} />
+
+<img src="foo.jpg" />
+
+<style lang="scss">
+  @use "sourcemapImport.scss";
+  @use "sass:color";
+  .sourcemap {
+    $primary-color: #6b717f;
+    color: $primary-color;
+    border: 1px solid color.scale($primary-color, $lightness: 20%);
+  }
+</style>

--- a/test/fixtures/preprocessing-sourcemaps/svelte.config.js
+++ b/test/fixtures/preprocessing-sourcemaps/svelte.config.js
@@ -2,5 +2,5 @@ const { typescript } = require("svelte-preprocess-esbuild");
 const { sass } = require("svelte-preprocess-sass");
 
 module.exports = {
-    preprocess: [{ style: sass() }, typescript()]
+    preprocess: [{ style: sass() }, typescript()],
 };

--- a/test/fixtures/preprocessing-sourcemaps/svelte.config.js
+++ b/test/fixtures/preprocessing-sourcemaps/svelte.config.js
@@ -1,0 +1,6 @@
+const { typescript } = require("svelte-preprocess-esbuild");
+const { sass } = require("svelte-preprocess-sass");
+
+module.exports = {
+    preprocess: [{ style: sass() }, typescript()]
+};

--- a/test/sourcemapsTest.mjs
+++ b/test/sourcemapsTest.mjs
@@ -16,7 +16,11 @@ test("Preprocessor Sourcemap test", async () => {
         sourcemap: "external",
         outdir: "out",
         plugins: [sveltePlugin({ preprocess: [{ style: sass() }, typescript()] })],
+        logLevel: "silent",
     });
+
+    assert.equal(result.warnings.length, 1, "Should one warning"); // because of warnings tests
+    assert.equal(result.errors.length, 0, "Should not have errors");
 
     assert.equal(result.outputFiles.length, 4);
 

--- a/test/warnings.mjs
+++ b/test/warnings.mjs
@@ -81,7 +81,7 @@ test("Warnings are in the right spot", async () => {
     assert.equal(
         results.warnings[0].location.lineText,
         "  {#if MY_GLOBAL}",
-        "Line text is correct"
+        "Line text is correct",
     );
     assert.match(results.warnings[0].text, /'MY_GLOBAL' is not defined/);
 });

--- a/test/warnings.mjs
+++ b/test/warnings.mjs
@@ -2,6 +2,7 @@ import { test } from "uvu";
 import * as assert from "uvu/assert";
 import { build as _build } from "esbuild";
 import { typescript } from "svelte-preprocess-esbuild";
+import { sass } from "svelte-preprocess-sass";
 import sveltePlugin from "../dist/index.mjs";
 import commonOptions from "./commonOptions.js";
 
@@ -54,6 +55,59 @@ test("Can filter out warnings", async () => {
         "The not filtered warning is still there",
     );
     assert.equal(resultsWithFilter.errors.length, 0, "Should not have errors");
+});
+
+test("Warnings are in the right spot", async () => {
+    const results = await _build({
+        entryPoints: ["./test/fixtures/warnings/entry.js"],
+        outdir: "../example/dist",
+        bundle: true,
+        write: false, //Don't write anywhere
+        sourcemap: true,
+        plugins: [
+            sveltePlugin({
+                preprocess: typescript(),
+                compilerOptions: { dev: true },
+            }),
+        ],
+        logLevel: "silent",
+    });
+
+    assert.equal(results.warnings.length, 2, "Should have two warnings");
+    assert.equal(results.errors.length, 0, "Should not have errors");
+    assert.equal(results.warnings[0].location.column, 7, "Column is correct");
+    assert.equal(results.warnings[0].location.line, 3, "Line is correct");
+    assert.equal(results.warnings[0].location.length, 9, "Length is correct");
+    assert.equal(
+        results.warnings[0].location.lineText,
+        "  {#if MY_GLOBAL}",
+        "Line text is correct"
+    );
+    assert.match(results.warnings[0].text, /'MY_GLOBAL' is not defined/);
+});
+
+test("Preprocessor errors are as expected", async () => {
+    const results = await _build({
+        entryPoints: ["./test/fixtures/preprocessing-sourcemaps/pp-sourcemaps.js"],
+        outdir: "../example/dist",
+        format: "esm",
+        minify: true,
+        bundle: true,
+        splitting: true,
+        write: false, //Don't write anywhere
+        sourcemap: "external",
+        outdir: "out",
+        plugins: [sveltePlugin({ preprocess: [{ style: sass() }, typescript()] })],
+        logLevel: "silent",
+    });
+
+    assert.equal(results.outputFiles.length, 4);
+    assert.equal(results.warnings.length, 1, "Should have one warnings");
+    assert.equal(results.errors.length, 0, "Should not have errors");
+
+    assert.equal(results.warnings[0].location.column, 0, "Column is correct");
+    assert.equal(results.warnings[0].location.line, 25, "Line is correct");
+    assert.equal(results.warnings[0].location.length, 21, "Length is correct");
 });
 
 test.run();

--- a/test/warnings.mjs
+++ b/test/warnings.mjs
@@ -86,7 +86,7 @@ test("Warnings are in the right spot", async () => {
     assert.match(results.warnings[0].text, /'MY_GLOBAL' is not defined/);
 });
 
-test("Preprocessor errors are as expected", async () => {
+test("Preprocessor warnings are as expected", async () => {
     const results = await _build({
         entryPoints: ["./test/fixtures/preprocessing-sourcemaps/pp-sourcemaps.js"],
         outdir: "../example/dist",


### PR DESCRIPTION
Uses Mozilla's `source-map` library to parse the sourcemaps from preprocessors to correctly return the error/warning location in the original file.

Fixes #83 