### PR TITLE
add preloaders option

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,6 @@
 import type { CompileOptions, Warning } from "svelte/types/compiler/interfaces";
 import type { PreprocessorGroup } from "svelte/types/compiler/preprocess/types";
-import type { Plugin } from "esbuild";
+import type { Loader, OnLoadArgs, Plugin } from "esbuild";
 interface esbuildSvelteOptions {
     /**
      * Svelte compiler options
@@ -32,6 +32,9 @@ interface esbuildSvelteOptions {
      * Defaults to a constant function that returns `true`
      */
     filterWarnings?: (warning: Warning) => boolean;
+    preloaders?: {
+        [key in Loader]: (content: string, opts: OnLoadArgs) => string;
+    };
 }
 export default function sveltePlugin(options?: esbuildSvelteOptions): Plugin;
 export {};


### PR DESCRIPTION
There are loaders built into esbuild that cannot be controlled (unlike loader plugins, no options can be specified), in some cases their default behavior may not work as expected, and requires some preparation of the source code before this code is processed appropriate loader.

it would seem that this is a mere trifle. After all, there is probably an option that would disable the processing of such links at the time of building, putting this part at the discretion of the developer. But the loader did not have such an option. Just as there is no option to manually set the root directory to search for the images.

It would seem like a good idea for such a narrow purpose to write an independent plugin that would deal with the processing of absolute paths in styles. But as it turned out, esbuild [does not provide chain passing of execution from plugin to plugin](https://github.com/evanw/esbuild/issues/2872#issuecomment-1406922638), and thus processed files after processing went to the loader, and not to the svelte-esbuild plugin, and this completely spoiled the whole game.

And it seems to me that since it is impossible to influence loaders and introduce such functionality using plugins, it would be nice to make in such cases in the svelte-esbuild plugin itself the possibility of pre-processing the generated sources before they get processed by the corresponding loaders.

So, I suggest the following usage:

```js
esbuildSvelte({
   preprocess: sveltePreprocess(),            
   compilerOptions: {},
   preloaders: {
      css: (content, opts) =>{
         // changes absolute paths to relative
         const code = content.replace(/(\/static\/images)/g, function handleReplace(match) {
       
            let dirname = path.dirname(process.argv[1])
            let relPath = path.relative(opts.path, dirname + '/scripts') + '/images'                                 
            return relPath;
         });         
         return code;         
      }
   }
})
```

For example the above code changes all paths with `/static/images` to relative path depending on its location position



