### PR TITLE
In examples, add "svelte" to `conditions` in esbuild build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ esbuild
   .build({
     entryPoints: ["app.js"],
     mainFields: ["svelte", "browser", "module", "main"],
+    conditions: ["svelte"],
     bundle: true,
     outfile: "out.js",
     plugins: [sveltePlugin()],
@@ -53,6 +54,7 @@ esbuild
   .build({
     entryPoints: ["index.js"],
     mainFields: ["svelte", "browser", "module", "main"],
+    conditions: ["svelte"],
     bundle: true,
     outdir: "./dist",
     plugins: [
@@ -63,6 +65,10 @@ esbuild
   })
   .catch(() => process.exit(1));
 ```
+
+### `svelte` exports condition
+
+If you are importing a svelte component library, you need to add `"svelte"` to `conditions` in esbuild build options. This lets esbuild use the `svelte` property in svelte component's `exports` conditions in `package.json` .
 
 ## Advanced
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ esbuild
   .build({
     entryPoints: ["app.js"],
     mainFields: ["svelte", "browser", "module", "main"],
-    conditions: ["svelte"],
+    conditions: ["svelte", "browser"],
     bundle: true,
     outfile: "out.js",
     plugins: [sveltePlugin()],
@@ -54,7 +54,7 @@ esbuild
   .build({
     entryPoints: ["index.js"],
     mainFields: ["svelte", "browser", "module", "main"],
-    conditions: ["svelte"],
+    conditions: ["svelte", "browser"],
     bundle: true,
     outdir: "./dist",
     plugins: [

--- a/example-js/buildscript.js
+++ b/example-js/buildscript.js
@@ -12,6 +12,7 @@ esbuild
     .build({
         entryPoints: ["./entry.js"],
         mainFields: ["svelte", "browser", "module", "main"],
+        conditions: ["svelte"],
         outdir: "./dist",
         format: "esm",
         logLevel: "info",

--- a/example-js/buildscript.js
+++ b/example-js/buildscript.js
@@ -12,7 +12,7 @@ esbuild
     .build({
         entryPoints: ["./entry.js"],
         mainFields: ["svelte", "browser", "module", "main"],
-        conditions: ["svelte"],
+        conditions: ["svelte", "browser"],
         outdir: "./dist",
         format: "esm",
         logLevel: "info",

--- a/example-ts/buildscript.js
+++ b/example-ts/buildscript.js
@@ -13,7 +13,7 @@ esbuild
         bundle: true,
         outdir: `./dist`,
         mainFields: ["svelte", "browser", "module", "main"],
-        conditions: ["svelte"],
+        conditions: ["svelte", "browser"],
         // logLevel: `info`,
         minify: false, //so the resulting code is easier to understand
         sourcemap: "inline",

--- a/example-ts/buildscript.js
+++ b/example-ts/buildscript.js
@@ -13,6 +13,7 @@ esbuild
         bundle: true,
         outdir: `./dist`,
         mainFields: ["svelte", "browser", "module", "main"],
+        conditions: ["svelte"],
         // logLevel: `info`,
         minify: false, //so the resulting code is easier to understand
         sourcemap: "inline",


### PR DESCRIPTION
### Problem
Currently, when you try to import a svelte component library, you get the below error when building.
```
None of the conditions provided ("types", "svelte") match any of the currently active conditions
  ("browser", "default", "import", "module"):
``` 

**Steps to reproduce:**
1. `npx degit EMH333/esbuild-svelte/example-ts my-svelte-app`
2. `npm install svelte-french-toast` 
3. Add statement `import toast from "svelte-french-toast"` to code.
4. `npm install`, `npm run build`

### Solution
The solution is to add `conditions: ["svelte"],` to esbuild's build options. I had problem figuring it out as I couldn't find this information anywhere. So I added this information to examples in README and example projects.

Svelte plugins for other bundlers like rollup and webpack all state this information in their READMEs:
https://github.com/sveltejs/rollup-plugin-svelte#svelte-exports-condition
https://github.com/sveltejs/svelte-loader#resolveconditionnames